### PR TITLE
Use yield while delaying

### DIFF
--- a/FastLED.cpp
+++ b/FastLED.cpp
@@ -131,7 +131,7 @@ void CFastLED::delay(unsigned long ms) {
 		show();
 		yield();
 	}
-	while((millis()-start) < ms);
+	while((millis()-start) < ms) yield();
 }
 
 void CFastLED::setTemperature(const struct CRGB & temp) {


### PR DESCRIPTION
The chip should never be blocked without allowing background operations to be performed.